### PR TITLE
Resources Page fixes

### DIFF
--- a/app/components/ResourceCard.tsx
+++ b/app/components/ResourceCard.tsx
@@ -17,14 +17,17 @@ interface ResourceCardProps {
 
 const styles = {
   card: 'p-5 text-black space-y-3',
-  linkTitle: 'font-bold hover:underline',
-  grid: 'grid grid-cols-5 gap-x-10 leading-loose p-1',
+  linkTitle: 'text-[#EB9A60] md:text-black text-base font-bold hover:underline',
+  grid: 'grid md:grid-cols-5 gap-x-10 leading-loose p-1',
   description: 'col-span-3',
   flex: 'col-span-2 flex flex-col',
   boldText: 'font-bold',
   phoneMargin: 'mb-4',
   button:
-    'w-full self-center bg-[#FFB47F] hover:bg-[#FF9244] text-center font-medium py-2 px-10 rounded',
+    'hidden md:block w-full self-center bg-[#FFB47F] hover:bg-[#FF9244] text-center font-medium py-2 px-10 rounded',
+  mobileButton:
+    'block mx-auto bg-[#FFB47F] hover:bg-[#FF9244] text-center font-medium py-2 px-4 rounded',
+  mobileBtnBlock: 'block md:hidden w-full h-fit',
 };
 
 const ResourceCard = ({ resource, translationPath }: ResourceCardProps) => {
@@ -67,6 +70,16 @@ const ResourceCard = ({ resource, translationPath }: ResourceCardProps) => {
             {resource.button.text}
           </a>
         </div>
+      </div>
+      <div className={styles.mobileBtnBlock}>
+        <a
+          id='link'
+          href={resource.button.link}
+          target='_blank'
+          className={styles.mobileButton}
+        >
+          {resource.button.text}
+        </a>
       </div>
     </Card>
   );

--- a/app/components/ResourceCard.tsx
+++ b/app/components/ResourceCard.tsx
@@ -21,7 +21,6 @@ const styles = {
   grid: 'grid md:grid-cols-5 gap-x-10 leading-loose p-1',
   description: 'col-span-3',
   flex: 'col-span-2 flex flex-col',
-  boldText: 'font-bold',
   phoneMargin: 'mb-4',
   button:
     'hidden md:block w-full self-center bg-[#FFB47F] hover:bg-[#FF9244] text-center font-medium py-2 px-10 rounded',
@@ -49,16 +48,17 @@ const ResourceCard = ({ resource, translationPath }: ResourceCardProps) => {
         </p>
         <div className={styles.flex}>
           {resource.location && (
-            <p id='location' className={styles.boldText}>
-              Location: {resource.location}
+            <p id='location'>
+              <strong>Location:</strong>
+              <br />
+              {resource.location}
             </p>
           )}
           {resource.phone && (
-            <p
-              id='phone'
-              className={`${styles.boldText} ${styles.phoneMargin}`}
-            >
-              Phone: {resource.phone}
+            <p id='phone' className={`${styles.phoneMargin}`}>
+              <strong>Phone:</strong>
+              <br />
+              {resource.phone}
             </p>
           )}
           <a

--- a/app/components/ResourcePage.tsx
+++ b/app/components/ResourcePage.tsx
@@ -31,7 +31,7 @@ export default function ResourcePage({ slug }: { slug: string }) {
       <Link href='/' className='hover:underline'>
         {t('resources.backToResources')}
       </Link>
-      <section className='flex flex-row py-5'>
+      <section className='flex flex-col md:flex-row py-5'>
         <div id='sidebar' className='basis-5/12'>
           <h1 className='text-2xl font-bold'>
             {t(`resources.categories.${slug}.name`)}

--- a/app/components/ResourcePage.tsx
+++ b/app/components/ResourcePage.tsx
@@ -2,9 +2,10 @@
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import ResourcesSection from '@/app/components/ResourcesSection';
-// import ResourcesSidebar from '@/app/components/ResourcesSideBar';
+import ResourcesSidebar from '@/app/components/ResourcesSideBar';
 import translations from '@/public/locales/en.json';
 import { useTranslation } from 'react-i18next';
+import { extractResourcesFromCategory } from '@/app/utils/extractResources';
 import {
   ResourceCategories,
   Subcategory,
@@ -23,6 +24,8 @@ export default function ResourcePage({ slug }: { slug: string }) {
     redirect('/');
   }
 
+  const extractedResources = extractResourcesFromCategory(category);
+
   return (
     <main className='text-white '>
       <Link href='/' className='hover:underline'>
@@ -33,7 +36,7 @@ export default function ResourcePage({ slug }: { slug: string }) {
           <h1 className='text-2xl font-bold'>
             {t(`resources.categories.${slug}.name`)}
           </h1>
-          {/* <ResourcesSidebar resources={category.resources} /> */}
+          <ResourcesSidebar resources={extractedResources} />
         </div>
         <div className='w-full'>
           {Object.keys(category.subcategories).map((key: string) => {

--- a/app/components/ResourcesSection.tsx
+++ b/app/components/ResourcesSection.tsx
@@ -16,13 +16,12 @@ export default function ResourcesSection({
 }: ResourcesSectionProps) {
   return (
     <div>
-      <h2 id={`${subcategoryKey}`} className='font-bold text-xl my-4'>
+      <h2 id={`${formatTitleToId(title)}`} className='font-bold text-xl my-4'>
         {capitalizeWords(title)}
       </h2>
       <div>
         {Object.keys(resources).map((resourceKey: string) => {
           const resource = resources[resourceKey];
-
           return (
             <div
               id={formatTitleToId(resource.name)}

--- a/app/components/ResourcesSideBar.tsx
+++ b/app/components/ResourcesSideBar.tsx
@@ -1,22 +1,9 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { capitalizeWords, formatTitleToId } from '@/app/utils/wordFormat';
-
-export interface Resource {
-  title: string;
-  link: string;
-  description: string;
-}
-
-export interface Category {
-  name: string;
-  data: Resource[];
-}
-
-export interface ResourcesSectionProps {
-  resources: Category[];
-}
+import { ResourcesSectionProps } from '@/app/constants/interfaces';
 
 const styles = {
   list: 'py-5 space-y-2',
@@ -33,6 +20,7 @@ const styles = {
 };
 
 export default function ResourcesSidebar({ resources }: ResourcesSectionProps) {
+  const { t } = useTranslation();
   const [openCategory, setOpenCategory] = useState('');
 
   const toggleCategory = (name: string) => {
@@ -73,17 +61,17 @@ export default function ResourcesSidebar({ resources }: ResourcesSectionProps) {
                 />
               </svg>
             </span>
-            {capitalizeWords(category.name)}
+            {capitalizeWords(t(category.name))}
           </h3>
           <ul className={styles.nestedList(openCategory === category.name)}>
             {category.data.map((resource, index) => (
               <li key={index} className={styles.listItemInner}>
                 <a
-                  onClick={(e) => handleScrollToElement(e, resource.title)}
-                  href={`#${formatTitleToId(resource.title)}`}
+                  onClick={(e) => handleScrollToElement(e, resource.name)}
+                  href={`#${formatTitleToId(resource.name)}`}
                   className={styles.link}
                 >
-                  {resource.title}
+                  {t(resource.name)}
                 </a>
               </li>
             ))}

--- a/app/constants/interfaces.ts
+++ b/app/constants/interfaces.ts
@@ -24,3 +24,13 @@ export interface ResourceCategories {
     };
   };
 }
+
+export interface Category {
+  name: string;
+  data: Resource[];
+  subcategoryKey: string;
+}
+
+export interface ResourcesSectionProps {
+  resources: Category[];
+}

--- a/app/utils/extractResources.tsx
+++ b/app/utils/extractResources.tsx
@@ -1,0 +1,14 @@
+import { Category, Subcategory } from '@/app/constants/interfaces';
+
+export const extractResourcesFromCategory = (category: {
+  subcategories: Record<string, Subcategory>;
+}): Category[] => {
+  return Object.keys(category.subcategories).map((key) => {
+    const subcategory = category.subcategories[key];
+    return {
+      name: subcategory.name,
+      data: Object.values(subcategory.entries),
+      subcategoryKey: key,
+    };
+  });
+};

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -41,7 +41,7 @@
     "heading": "RECURSOS",
     "subheading": "Encuentra los recursos que necesitas para prosperar en tu comunidad.",
     "viewMoreResources": "VER MÁS RECURSOS",
-    "backToResources": "Volver a Recursos",
+    "backToResources": "Volver A Recursos",
     "categories": {
       "housing-stability": {
         "path": "housing-stability",


### PR DESCRIPTION
This PR addresses the following:


**Adds sidebar in resource category page** - used existing component, extracted subcategory information into new util `extractResources.tsx`

Before:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/7a8e2629-9c65-4c0e-9259-94c11efcc97f">


After:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/72c51b18-6a4d-4012-b3d4-631908dd5107">

**Adjust for mobile display**

Before:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/7c9efa72-a073-4c89-ba96-289735fccf06">


After:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2f1c276e-9982-4ccc-838b-db80beef9c0f">


**Links for subcategories from main page** - correctly href logic from main page to correctly anchor to sub category title

**Adds 'back to resources' translation** - should double check translation

Before:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/417fd044-996e-4778-bd79-3a53bd32f320">


After:

<img width="250" alt="image" src="https://github.com/user-attachments/assets/55bb6158-3d43-4406-aeeb-2795227820e4">

